### PR TITLE
[Dev-120] Update image in docker-compose.yml to point to latest version in DockerHub

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   replicator:
     container_name: repl-replicator
-    image: eu.gcr.io/esc-platform-advocacy/eventstore/replicator:latest
+    image: eventstore/replicator:latest
     ports:
       - "5000:5000"
     volumes:


### PR DESCRIPTION
The newer versions are more resilient to network issues. Customers have reported issues with the previous version which are resolved with newer versions. They usually use this docker-compose.yml file as reference, hence this proposed change.