### PR TITLE
DEV-275 - Temporarily downgrade to NET7 to resolve runtime issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG RUNNER_IMG
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0 AS builder
 ARG TARGETARCH
 
 WORKDIR /app
@@ -23,7 +23,7 @@ ARG TARGETARCH
 COPY ./src ./src
 RUN dotnet publish ./src/es-replicator -c Release -a $TARGETARCH -clp:NoSummary --no-self-contained -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runner
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS runner
 
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <LangVersion>11</LangVersion>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <NoWarn>$(NoWarn);CS1591;CS0618;</NoWarn>

--- a/src/es-replicator/es-replicator.csproj
+++ b/src/es-replicator/es-replicator.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
         <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.15" />
         <PackageReference Include="Ubiquitous.Metrics.Prometheus" Version="0.4.0" />
         <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
     </ItemGroup>

--- a/test/EventStore.Replicator.Tests/EventStore.Replicator.Tests.csproj
+++ b/test/EventStore.Replicator.Tests/EventStore.Replicator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <LangVersion>11</LangVersion>
         <IsPackable>false</IsPackable>
         <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Changed: Downgrades to NET7 SDK/Runtime temporarily due to runtime/compatibility issues with packages on older versions of .NET.

Will be fixed and upgraded to NET8 in a future PR.

See https://github.com/EventStore/replicator/pull/85#issuecomment-1936401244