### PR TITLE
DEV-275 - Upgrade Ubiquitous.Metrics to support NET8

### DIFF
--- a/src/EventStore.Replicator.Shared/EventStore.Replicator.Shared.csproj
+++ b/src/EventStore.Replicator.Shared/EventStore.Replicator.Shared.csproj
@@ -5,7 +5,7 @@
 
     <ItemGroup>
         <PackageReference Include="LibLog" Version="5.0.8" PrivateAssets="All" />
-        <PackageReference Include="Ubiquitous.Metrics" Version="0.4.1-alpha.0.3" />
+        <PackageReference Include="Ubiquitous.Metrics" Version="0.5.0" />
         <PackageReference Include="YamlDotNet" Version="15.1.1" />
         <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
     </ItemGroup>

--- a/src/EventStore.Replicator.Shared/EventStore.Replicator.Shared.csproj
+++ b/src/EventStore.Replicator.Shared/EventStore.Replicator.Shared.csproj
@@ -5,7 +5,7 @@
 
     <ItemGroup>
         <PackageReference Include="LibLog" Version="5.0.8" PrivateAssets="All" />
-        <PackageReference Include="Ubiquitous.Metrics" Version="0.4.0" />
+        <PackageReference Include="Ubiquitous.Metrics" Version="0.4.1-alpha.0.3" />
         <PackageReference Include="YamlDotNet" Version="15.1.1" />
         <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
     </ItemGroup>

--- a/src/es-replicator/es-replicator.csproj
+++ b/src/es-replicator/es-replicator.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.1" />
-        <PackageReference Include="Ubiquitous.Metrics.Prometheus" Version="0.4.0" />
+        <PackageReference Include="Ubiquitous.Metrics.Prometheus" Version="0.4.1-alpha.0.3" />
         <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
     </ItemGroup>
 

--- a/src/es-replicator/es-replicator.csproj
+++ b/src/es-replicator/es-replicator.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.1" />
-        <PackageReference Include="Ubiquitous.Metrics.Prometheus" Version="0.4.1-alpha.0.3" />
+        <PackageReference Include="Ubiquitous.Metrics.Prometheus" Version="0.5.0" />
         <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Changed: Upgraded `Ubiquitous.Metrics` package to latest to resolve NET8 runtime exception.