### PR TITLE
DEV-279 - Add Docker Build and PR Check Workflows

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,29 @@
+name: Build Docker Image
+on:
+  push:
+    paths:
+      - 'src/**'
+    branches:
+      - 'master'
+  pull_request:
+    paths:
+      - 'src/**'
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,5 +1,4 @@
-name: Helm Publish
-
+name: Publish Helm Chart
 on:
   push:
     paths:
@@ -8,11 +7,17 @@ on:
       - master
 
 jobs:
-  build:
+  helm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: J12934/helm-gh-pages-action@master
-        with:
-          access-token: ${{ secrets.ACCESS_TOKEN }}
-          deploy-branch: gh-pages
+      - 
+        name: Checkout
+        uses: actions/checkout@v3
+      - 
+        name: Install Helm
+        uses: azure/setup-helm@v3
+      - 
+        name: Publish Helm Chart
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,5 +1,4 @@
-name: "Build and push Docker"
-
+name: Publish Docker Image
 on:
   push:
     paths:
@@ -8,9 +7,6 @@ on:
       - 'master'
     tags:
       - '*.*.*'
-  pull_request:
-    branches:
-      - 'master'
 
 jobs:
   docker:
@@ -18,37 +14,35 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       -
-        name: Docker meta
-        id: meta
+        name: Set up Docker metadata
         uses: docker/metadata-action@v3
         with:
           images: |
             eventstore/replicator
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
         name: Login to DockerHub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push
+        name: Publish
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -1,0 +1,23 @@
+name: Pull Request Check
+on:
+  pull_request:
+    paths-ignore:
+      - "test/**"
+      - "example/**"
+      - "**.md"
+      - ".github/**"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+    types: [opened, edited]
+jobs:
+  checkPullRequest:
+    name: Pull Request check
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v3
+      - 
+        name: Check pull requests
+        uses: EventStore/Automations/pr-check@master


### PR DESCRIPTION
Added: PR check workflow to validate pull requests.
Changed: Split Docker build and publish workflows, to allow Docker build check on pull requests.
Changed: Reduced number of individual images tagged on publish, to keep docker hub registry clear.
Changed: Added QEMU to support compiling for arm64.
Changed: Fixed the helm publish workflow, update to use helm official action and only publish on release tag.