### PR TITLE
Fix default listen port to match deployment assets

### DIFF
--- a/src/replicator/appsettings.json
+++ b/src/replicator/appsettings.json
@@ -1,4 +1,4 @@
 {
   "AllowedHosts": "*",
-  "Urls": "http://*:5098"
+  "Urls": "http://*:5000"
 }


### PR DESCRIPTION
## Summary

- `src/replicator/appsettings.json` hardcoded `"Urls": "http://*:5098"`, which **wins over the `ASPNETCORE_URLS` env var** that the Dockerfile sets to `http://*:5000`. Result: the container listens on 5098 by default.
- Every piece of deployment config assumes 5000: `Dockerfile` `EXPOSE 5000` / `ENV ASPNETCORE_URLS`, `compose/docker-compose.yml` `5000:5000`, `compose/prometheus.yml` scrape target `replicator:5000`, `charts/replicator/templates/service.yaml` (`prometheus.io/port: "5000"`, `port: 5000`, `targetPort: 5000`), `charts/replicator/templates/statefulset.yaml` probes/container port 5000, and the docs (`docs/src/content/docs/deployment/docker.mdx` → http://localhost:5000).
- So the published image's metrics endpoint was unreachable from any Prometheus scraper wired up per the shipped compose/Helm assets. Setting `ASPNETCORE_URLS` at deploy time does **not** fix it, because `appsettings.json` is a later config source in the running app.

This PR changes the bundled default to `http://*:5000`, aligning the app with the rest of the deployment stack.

## Reproduction (before fix)

```
$ docker build -t replicator:repro .
$ docker run -d --name r -v <cfg>:/app/config -p 15000:5000 -p 15098:5098 replicator:repro
$ docker exec r sh -c 'echo $ASPNETCORE_URLS'
http://*:5000
$ docker logs r | grep listening
"Now listening on: \"http://[::]:5098\""
$ curl -o /dev/null -w '%{http_code}\n' http://localhost:15000/metrics
000
$ curl -o /dev/null -w '%{http_code}\n' http://localhost:15098/metrics
200
```

## After fix

```
$ docker logs r | grep listening
"Now listening on: \"http://[::]:5000\""
$ curl -o /dev/null -w '%{http_code}\n' http://localhost:15000/metrics
200
```

## Test plan

- [ ] `docker build .` succeeds
- [ ] Container started from the built image listens on `:5000` (confirm via logs and `curl /metrics`)
- [ ] `docker compose -f compose/docker-compose.yml up` — Prometheus at :9090 shows the `replicator` target as UP and scrapes metrics
- [ ] Helm chart deploy — liveness/readiness probes on `:5000` pass, service scraping works
- [ ] Local `dotnet run --project src/replicator` still starts (UI/metrics now on `:5000` locally too; previously `:5098`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)